### PR TITLE
Update managed_identity.py

### DIFF
--- a/generators/managed_identity/managed_identity.py
+++ b/generators/managed_identity/managed_identity.py
@@ -714,7 +714,7 @@ resource "azurerm_windows_virtual_machine" "managed_identity" {
   name                          = local.mi_friendly_name 
   resource_group_name           = azurerm_resource_group.pcmi.name 
   location                      = var.mi_location
-  size                       = "Standard_A1"
+  size                       = "Standard_A1_v2"
   computer_name  = local.micomputername
   admin_username = var.mi_admin_username
   admin_password = local.micreds 


### PR DESCRIPTION
The standard a1 is not available on new azure account on accounts on retirement. v2 works really well and no issues. 

sed]
azurerm_windows_virtual_machine.managed_identity: Still creating... [7m40s elapsed]
azurerm_windows_virtual_machine.managed_identity: Still creating... [7m50s elapsed]
azurerm_windows_virtual_machine.managed_identity: Still creating... [8m0s elapsed]
azurerm_windows_virtual_machine.managed_identity: Still creating... [8m10s elapsed]
azurerm_windows_virtual_machine.managed_identity: Still creating... [8m20s elapsed]
azurerm_windows_virtual_machine.managed_identity: Still creating... [8m30s elapsed]
azurerm_windows_virtual_machine.managed_identity: Creation complete after 8m37s [id=/subscriptions/f7c7d5de-5e02-4157-800b-1b14c854eb63/resourceGroups/purpleidentityovd2w/providers/Microsoft.Compute/virtualMachines/purpleidentityovd2w]

Apply complete! Resources: 45 added, 0 changed, 0 destroyed.                 
            