### PR TITLE
Jinja2 instead of template_file.

### DIFF
--- a/generators/phishing_app/phishing_app.py
+++ b/generators/phishing_app/phishing_app.py
@@ -5,6 +5,9 @@
 import os.path
 import argparse
 
+# Jinaj2 Templates for the Templates themselves.
+from jinja2 import Environment, FileSystemLoader
+
 # argparser stuff
 parser = argparse.ArgumentParser(description='A script to create terraform for a consent phishing app')
 
@@ -58,157 +61,21 @@ else:
     default_logout_url = args.logout_url
     print("[+] User supplied logout_url: ", default_logout_url)
 
-#####
-# Functions
-#####
+# This is a test for using Jinja2
+file_loader = FileSystemLoader('templates')
+env = Environment(loader=file_loader)
 
-# Get the terraform template
-def get_code_template():
-    template = '''
-
-variable "display_name" {
-  description = "The application display name"
-  default = "DISPLAY_NAME"
-}
-
-variable "redirect_uris" {
-  default = "REDIRECT_URIS"
-}
-
-variable "homepage_url" {
-  default = "HOMEPAGE_URL"
-}
-
-variable "logout_url" {
-  default = "LOGOUT_URL"
-}
-
-resource "azuread_application_password" "app_consent" {
-  application_object_id = azuread_application.app_consent.object_id
-}
-
-data "azuread_client_config" "current" {}
-
-# Create service principal
-resource "azuread_service_principal" "app_consent" {
-  application_id = azuread_application.app_consent.application_id
-
- depends_on = [azuread_application.app_consent]
-}
-
-resource "azuread_application" "app_consent" {
-  display_name     = var.display_name
-  owners           = [data.azuread_client_config.current.object_id]
-  sign_in_audience = "AzureADMultipleOrgs"
-
-  feature_tags {
-    enterprise = true
-    gallery    = false
-  }
-
-  required_resource_access {
-    resource_app_id = "00000003-0000-0000-c000-000000000000" # Microsoft Graph
-
-    resource_access {
-      id   = "ff74d97f-43af-4b68-9f2a-b77ee6968c5d" # Contacts.Read
-      type = "Scope"
-    }
-
-    resource_access {
-      id   = "570282fd-fa5c-430d-a7fd-fc8dc98a9dca" #  Mail.Read
-      type = "Scope"
-    }
-
-    resource_access {
-      id   = "e383f46e-2787-4529-855e-0e479a3ffac0" #  Mail.Send
-      type = "Scope"
-    }
-
-    resource_access {
-      id   = "10465720-29dd-4523-a11a-6a75c743c9d9" # Files.Read
-      type = "Scope"
-    }
-
-    resource_access {
-      id   = "df85f4d6-205c-4ac5-a5ea-6bf408dba283" # Files.Read.All
-      type = "Scope"
-    }
-
-    resource_access {
-      id   = "863451e7-0667-486c-a5d6-d135439485f0" # Files.ReadWrite.All
-      type = "Scope"
-    }
-
-    resource_access {
-      id   = "e1fe6dd8-ba31-4d61-89e7-88639da4683d" # User.Read
-      type = "Scope"
-    }
-
-  }
-
-  web {
-    homepage_url  = var.homepage_url
-    logout_url    = var.logout_url
-    redirect_uris = [var.redirect_uris]
-  }
-}
-
-output "client_secret" {
-  value = azuread_application_password.app_consent.value
-  description = "The client secret"
-  sensitive = true
-}
-
-output "app_details" {
-  value = <<EOS
-
--------------------
-Application Details
--------------------
-Name:  ${azuread_application.app_consent.display_name}
-Client Id:  ${azuread_application.app_consent.application_id}
-Redirect URL: ${var.redirect_uris}
-To get the client_secret value:  terraform output client_secret
--------------------
-Delegated scope Graph API Permissions
--------------------
-Contacts.Read
-Mail.Read
-Mail.Send
-Files.Read
-Files.Read.All
-Files.ReadWrite.All
-User.Read
-
-EOS
-}
-'''
-    return template
-# End of terraform template
-
-# Write the phishing_app.tf file 
-app_text_file = open(tapp_file, "w")
-
-# Get the code template
-default_app_template = get_code_template()
-
-# replace the app display name variable
-default_app_template = default_app_template.replace("DISPLAY_NAME",default_name) 
-
-# replace the redirect_uris 
-default_app_template = default_app_template.replace("REDIRECT_URIS",default_redirect_uris) 
-
-# replace the homepage_url 
-default_app_template = default_app_template.replace("HOMEPAGE_URL",default_homepage_url) 
-
-# replace the logout_url 
-default_app_template = default_app_template.replace("LOGOUT_URL",default_logout_url) 
-
-# write the file
-n = app_text_file.write(default_app_template)
+template = env.get_template('phishing_app.jinja')
+output = template.render(
+  DISPLAY_NAME=default_name,
+  REDIRECT_URIS=default_redirect_uris,
+  HOMEPAGE_URL=default_homepage_url,
+  LOGOUT_URL=default_logout_url
+)
 
 # print
-print("[+] Creating the phishing app terraform file: ",tapp_file)
+print("[+] Creating the phishing app terraform file: ")
 
-# close the file
-app_text_file.close()
+with open("phishing_app.tf", "w") as f:
+    f.write(output)
+ 

--- a/generators/phishing_app/templates/phishing_app.jinja
+++ b/generators/phishing_app/templates/phishing_app.jinja
@@ -1,0 +1,116 @@
+variable "display_name" {
+  description = "The application display name"
+  default = "{{ DISPLAY_NAME }}"
+}
+
+variable "redirect_uris" {
+  default = "{{ REDIRECT_URIS }}"
+}
+
+variable "homepage_url" {
+  default = "{{ HOMEPAGE_URL }}"
+}
+
+variable "logout_url" {
+  default = "{{ LOGOUT_URL }}"
+}
+
+resource "azuread_application_password" "app_consent" {
+  application_object_id = azuread_application.app_consent.object_id
+}
+
+data "azuread_client_config" "current" {}
+
+# Create service principal
+resource "azuread_service_principal" "app_consent" {
+  application_id = azuread_application.app_consent.application_id
+
+ depends_on = [azuread_application.app_consent]
+}
+
+resource "azuread_application" "app_consent" {
+  display_name     = var.display_name
+  owners           = [data.azuread_client_config.current.object_id]
+  sign_in_audience = "AzureADMultipleOrgs"
+
+  feature_tags {
+    enterprise = true
+    gallery    = false
+  }
+
+  required_resource_access {
+    resource_app_id = "00000003-0000-0000-c000-000000000000" # Microsoft Graph
+
+    resource_access {
+      id   = "ff74d97f-43af-4b68-9f2a-b77ee6968c5d" # Contacts.Read
+      type = "Scope"
+    }
+
+    resource_access {
+      id   = "570282fd-fa5c-430d-a7fd-fc8dc98a9dca" #  Mail.Read
+      type = "Scope"
+    }
+
+    resource_access {
+      id   = "e383f46e-2787-4529-855e-0e479a3ffac0" #  Mail.Send
+      type = "Scope"
+    }
+
+    resource_access {
+      id   = "10465720-29dd-4523-a11a-6a75c743c9d9" # Files.Read
+      type = "Scope"
+    }
+
+    resource_access {
+      id   = "df85f4d6-205c-4ac5-a5ea-6bf408dba283" # Files.Read.All
+      type = "Scope"
+    }
+
+    resource_access {
+      id   = "863451e7-0667-486c-a5d6-d135439485f0" # Files.ReadWrite.All
+      type = "Scope"
+    }
+
+    resource_access {
+      id   = "e1fe6dd8-ba31-4d61-89e7-88639da4683d" # User.Read
+      type = "Scope"
+    }
+
+  }
+
+  web {
+    homepage_url  = var.homepage_url
+    logout_url    = var.logout_url
+    redirect_uris = [var.redirect_uris]
+  }
+}
+
+output "client_secret" {
+  value = azuread_application_password.app_consent.value
+  description = "The client secret"
+  sensitive = true
+}
+
+output "app_details" {
+  value = <<EOS
+
+-------------------
+Application Details
+-------------------
+Name:  ${azuread_application.app_consent.display_name}
+Client Id:  ${azuread_application.app_consent.application_id}
+Redirect URL: ${var.redirect_uris}
+To get the client_secret value:  terraform output client_secret
+-------------------
+Delegated scope Graph API Permissions
+-------------------
+Contacts.Read
+Mail.Read
+Mail.Send
+Files.Read
+Files.Read.All
+Files.ReadWrite.All
+User.Read
+
+EOS
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Jinja~=3.1.2
+jinja-cli~=1.2.2


### PR DESCRIPTION
While working on a different project, I came across a great idea for building Terraform Templates. This came from the Amazon Account Factory Terraform modules, which use jinja-cli to convert Jinja templates into Terraform files. I decided to refactor your phishing_app template. Please note the following:

- templates/phishing_app. Jinja would be where the Jinja based terraform module will live within the generator
- phishing_app.py is much smaller, with less code required to make it work. You will need to have a requirements.txt that installed Jinja2 itself.