### PR TITLE
Update Terraform formatting to fix app creation errors (client_id, application_id)

### DIFF
--- a/generators/phishing_app/phishing_app.py
+++ b/generators/phishing_app/phishing_app.py
@@ -84,16 +84,16 @@ variable "logout_url" {
 }
 
 resource "azuread_application_password" "app_consent" {
-  application_object_id = azuread_application.app_consent.object_id
+  application_id = "/applications/${azuread_application.app_consent.object_id}"
 }
 
 data "azuread_client_config" "current" {}
 
 # Create service principal
 resource "azuread_service_principal" "app_consent" {
-  application_id = azuread_application.app_consent.application_id
+  client_id = azuread_application.app_consent.client_id
 
- depends_on = [azuread_application.app_consent]
+  depends_on = [azuread_application.app_consent]
 }
 
 resource "azuread_application" "app_consent" {
@@ -166,7 +166,7 @@ output "app_details" {
 Application Details
 -------------------
 Name:  ${azuread_application.app_consent.display_name}
-Client Id:  ${azuread_application.app_consent.application_id}
+Client Id:  ${azuread_application.app_consent.client_id}
 Redirect URL: ${var.redirect_uris}
 To get the client_secret value:  terraform output client_secret
 -------------------


### PR DESCRIPTION
These changes update formatting to fix errors I encountered during a recent run of the `phishing_app.py` generator.

Specifically, Terraform Azure AD seems to have made some formatting changes:
- Using `client_id` in place of `application_id` in `azuread_service_principal`
- Using `application_id` and `/applications/[appid]` in place of `application_object_id` in `azuread_application_password`

With these changes, the app is successfully created. Here's an example of it requesting all perms after testing the changes out:
<img width="567" alt="Screenshot 2024-11-28 at 9 35 33 AM" src="https://github.com/user-attachments/assets/972af5d6-ad3c-42e8-9b4f-607a5636c3f5">

Thank you for creating this generator! It's incredibly helpful for testing.